### PR TITLE
fix: correct bull package import for commonJs

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2,7 +2,7 @@ import { createBullBoard } from '@bull-board/api';
 import { BullAdapter } from '@bull-board/api/bullAdapter.js';
 import { BullMQAdapter } from '@bull-board/api/bullMQAdapter.js';
 import { ExpressAdapter } from '@bull-board/express';
-import * as LegacyQueue from 'bull';
+import LegacyQueue from 'bull';
 import { Queue } from 'bullmq';
 import { ensureLoggedIn } from 'connect-ensure-login';
 import express from 'express';


### PR DESCRIPTION
when running in docker, it throws an error: `TypeError: LegacyQueue is not a constructor` 